### PR TITLE
[SASS-11421] Add Controller, View and Form for new page

### DIFF
--- a/app/controllers/businessTaxReliefs/PostCessationTradeReliefController.scala
+++ b/app/controllers/businessTaxReliefs/PostCessationTradeReliefController.scala
@@ -17,21 +17,16 @@
 package controllers.businessTaxReliefs
 
 import actions.AuthorisedAction
-import config.{AppConfig, ErrorHandler}
-import forms.AmountForm
+import config.AppConfig
 import forms.businessTaxReliefs.PostCessationTradeReliefForm
 import models.requests.AuthorisationRequest
-import models.{AllGainsSessionModel, User}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
-import services.GainsSessionServiceProvider
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.pages.businessTaxReliefs.PostCessationTradeReliefView
-import views.html.pages.gains.PaidTaxAmountPageView
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class PostCessationTradeReliefController @Inject()(authorisedAction: AuthorisedAction,

--- a/app/controllers/businessTaxReliefs/PostCessationTradeReliefController.scala
+++ b/app/controllers/businessTaxReliefs/PostCessationTradeReliefController.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.businessTaxReliefs
+
+import actions.AuthorisedAction
+import config.{AppConfig, ErrorHandler}
+import forms.AmountForm
+import forms.businessTaxReliefs.PostCessationTradeReliefForm
+import models.requests.AuthorisationRequest
+import models.{AllGainsSessionModel, User}
+import play.api.data.Form
+import play.api.i18n.I18nSupport
+import play.api.mvc._
+import services.GainsSessionServiceProvider
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import views.html.pages.businessTaxReliefs.PostCessationTradeReliefView
+import views.html.pages.gains.PaidTaxAmountPageView
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class PostCessationTradeReliefController @Inject()(authorisedAction: AuthorisedAction,
+                                                   view: PostCessationTradeReliefView)
+                                                  (implicit mcc: MessagesControllerComponents, appConfig: AppConfig)
+  extends FrontendController(mcc) with I18nSupport {
+
+  def show(taxYear: Int): Action[AnyContent] = authorisedAction { implicit request =>
+    renderView(Ok, taxYear, PostCessationTradeReliefForm())
+  }
+
+  def submit(taxYear: Int): Action[AnyContent] = authorisedAction { implicit request =>
+    PostCessationTradeReliefForm().bindFromRequest().fold(
+      renderView(BadRequest, taxYear, _),
+      _ =>
+        //TODO:
+        // - Save the data to the User Answers (future story)
+        // - Redirect to CYA (future story)
+        NotImplemented
+    )
+  }
+
+  private def renderView(status: Status, taxYear: Int, form: Form[BigDecimal])(implicit request: AuthorisationRequest[_]): Result =
+    status(view(taxYear, form, routes.PostCessationTradeReliefController.submit(taxYear)))
+}

--- a/app/forms/businessTaxReliefs/PostCessationTradeReliefForm.scala
+++ b/app/forms/businessTaxReliefs/PostCessationTradeReliefForm.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.businessTaxReliefs
+
+import forms.validation.mappings.MappingUtil.currency
+import models.requests.AuthorisationRequest
+import play.api.data.Form
+import play.api.i18n.Messages
+import utils.ViewUtils.dynamicMessage
+
+object PostCessationTradeReliefForm {
+
+  val key: String = "amount"
+
+  def apply()(implicit messages: Messages, request: AuthorisationRequest[_]): Form[BigDecimal] =
+    Form(
+      key -> currency(
+        requiredKey = dynamicMessage("postCessationTradeRelief.amount.error.required"),
+        wrongFormatKey = messages("postCessationTradeRelief.amount.error.invalid"),
+        maxAmountKey = dynamicMessage("postCessationTradeRelief.amount.error.max"),
+        minAmountKey = Some(dynamicMessage("postCessationTradeRelief.amount.error.min"))
+      )
+    )
+}

--- a/app/utils/ViewUtils.scala
+++ b/app/utils/ViewUtils.scala
@@ -16,6 +16,7 @@
 
 package utils
 
+import models.requests.AuthorisationRequest
 import play.api.i18n.Messages
 import play.api.mvc.Call
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
@@ -68,4 +69,7 @@ object ViewUtils {
     val translatedMonth = messages("common." + date.getMonth.toString.toLowerCase)
     s"${date.getDayOfMonth} $translatedMonth ${date.getYear}"
   }
+
+  def dynamicMessage(key: String, args: String*)(implicit messages: Messages, request: AuthorisationRequest[_]): String =
+    messages(key + (if(request.user.isAgent) ".agent" else ".individual"), args: _*)
 }

--- a/app/views/pages/businessTaxReliefs/PostCessationTradeReliefView.scala.html
+++ b/app/views/pages/businessTaxReliefs/PostCessationTradeReliefView.scala.html
@@ -1,0 +1,95 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import views.html.templates.Layout
+@import views.html.templates.helpers.Heading
+@import views.html.templates.helpers.InputText
+@import views.html.templates.helpers.Button
+@import views.html.templates.helpers.ErrorSummary
+@import views.html.templates.helpers
+@import utils.ViewUtils._
+@import views.html.templates.helpers.P
+@import play.twirl.api.HtmlFormat
+
+@import models.requests.AuthorisationRequest
+
+@this(
+        layout: Layout,
+        heading: Heading,
+        errorSummary: ErrorSummary,
+        formWithCsrf: FormWithCSRF,
+        inputText: InputText,
+        p: P,
+        details: helpers.Details,
+        bullets: helpers.BulletList,
+        button: Button
+)
+@(taxYear: Int, form: Form[BigDecimal], action: Call)(implicit request: AuthorisationRequest[_], messages: Messages, appConfig: AppConfig)
+
+@layout(
+    pageTitle = messages("postCessationTradeRelief.title"),
+    taxYear = Some(taxYear),
+    hasErrors = form.hasErrors,
+    isAgent = request.user.isAgent
+) {
+
+    @errorSummary(form.errors)
+
+    @heading(messages("postCessationTradeRelief.title"))
+
+    @p { @(dynamicMessage("postCessationTradeRelief.p1")) }
+    @p { @(messages("postCessationTradeRelief.p2")) }
+
+    @details(messages("postCessationTradeRelief.summary.expenses.heading"), id = Some("detailExpenses"), content = {
+        HtmlFormat.fill(Seq(
+            p(Html(messages("postCessationTradeRelief.summary.expenses.p1"))),
+            bullets(Seq(
+                Html(messages("postCessationTradeRelief.summary.expenses.bullet1")),
+                Html(messages("postCessationTradeRelief.summary.expenses.bullet2")),
+                Html(messages("postCessationTradeRelief.summary.expenses.bullet3")),
+                Html(messages("postCessationTradeRelief.summary.expenses.bullet4"))
+            ))
+        ))
+    })
+
+    @details(messages("postCessationTradeRelief.summary.liabilities.heading"), id = Some("detailLiabilities"), content =  {
+        p(Html(dynamicMessage("postCessationTradeRelief.summary.liabilities.p1")))
+    })
+
+    @details(messages("postCessationTradeRelief.summary.loss.heading"), id = Some("detailLoss"), content = {
+        p(Html(messages("postCessationTradeRelief.summary.loss.p1")))
+    })
+
+    @formWithCsrf(action) {
+
+        @inputText(
+            form = form,
+            id = "amount",
+            name = "amount",
+            currency = true,
+            label = dynamicMessage(s"postCessationTradeRelief.label"),
+            labelClasses = Some("govuk-label--m")
+        )
+
+        @button()
+
+    }
+
+}
+
+@{
+    // $COVERAGE-OFF$
+}

--- a/app/views/templates/helpers/BulletList.scala.html
+++ b/app/views/templates/helpers/BulletList.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,10 @@
 
 @this()
 
-@(content: Html, classes: String = "govuk-body", id: Option[String] = None)
+@(elements: Seq[Html], classes: String = "govuk-list govuk-list--bullet", id: Option[String] = None)
 
-@if(id.isDefined){
-    <p class="@classes" id ="@id">@content</p>
-} else {
-    <p class="@classes">@content</p>
-}
-
-@{
-//$COVERAGE-OFF$
-}
+<ul class="@classes" @id.map{id => id="@id"}>
+    @elements.map { element =>
+        <li class="dashed-list-item">@element</li>
+    }
+</ul>

--- a/app/views/templates/helpers/Heading.scala.html
+++ b/app/views/templates/helpers/Heading.scala.html
@@ -16,7 +16,7 @@
 
 @this()
 
-@(heading: String, caption: Option[String], extraClasses: String = "", size: String = "l")(implicit messages: Messages)
+@(heading: String, caption: Option[String] = None, extraClasses: String = "", size: String = "l")(implicit messages: Messages)
 
 <h1 class="govuk-heading-@{size} @extraClasses">
     @caption.map{ caption =>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -71,3 +71,8 @@ POST        /:taxYear/gains/policies-remove-confirmation/:sessionId    controlle
 
 GET         /:taxYear/gains/section-completed                          controllers.gains.SectionCompletedStateController.show(taxYear: Int)
 POST        /:taxYear/gains/section-completed                          controllers.gains.SectionCompletedStateController.submit(taxYear: Int)
+
+
+###########################     Business Tax Reliefs (Other Reliefs) pages     ####################################
+GET         /:taxYear/business-reliefs/post-cessation-trade-relief/relief-claimed   controllers.businessTaxReliefs.PostCessationTradeReliefController.show(taxYear: Int)
+POST        /:taxYear/business-reliefs/post-cessation-trade-relief/relief-claimed   controllers.businessTaxReliefs.PostCessationTradeReliefController.submit(taxYear: Int)

--- a/conf/messages
+++ b/conf/messages
@@ -308,6 +308,41 @@ taxYear-error-template.paragraph.1 = You can only enter information for the tax 
 taxYear-error-template.paragraph.1.single = You can only enter information for a valid tax year.
 taxYear-error-template.paragraph.2 = Check that you’ve entered the correct web address.
 
+#################       Business Tax Reliefs messages        ########################################
+
+### Post Cessation Trade Relief
+postCessationTradeRelief.title = Post-cessation trade relief and certain other losses
+
+postCessationTradeRelief.p1.individual = If you’ve paid expenses in connection with a business that has ceased, you may be able to get tax relief on those payments. This relief can only be claimed if you didn’t claim those expenses at the time the business ceased, or anywhere else in this or an earlier tax return. Post-cessation expenses are always set against post-cessation receipts first.
+postCessationTradeRelief.p1.agent = If your client has paid expenses in connection with a business that has ceased, they may be able to get tax relief on those payments. This relief can only be claimed if they didn’t claim those expenses at the time the business ceased, or anywhere else in this or an earlier tax return. Post-cessation expenses are always set against post-cessation receipts first.
+postCessationTradeRelief.p2 = The expenses must be paid within 7 years of your cessation, and should be claimed against the tax return for the year the expense was paid. The claim must also be made by the anniversary of the filing deadline for the tax year in question. For example, a claim for an expense paid in the tax year 6 April 2026 to 5 April 2027 must be made by 31 January 2029.
+
+postCessationTradeRelief.summary.expenses.heading = Post-cessation expenses
+postCessationTradeRelief.summary.expenses.p1 = Post-cessation expenses are expenses that would have been taken from the business’s profits had it not ceased trading. These expenses are:
+postCessationTradeRelief.summary.expenses.bullet1 = fixing defective work done, or replacing defective services or goods supplied
+postCessationTradeRelief.summary.expenses.bullet2 = any legal or professional costs for any claim against you for defective work
+postCessationTradeRelief.summary.expenses.bullet3 = insurance against such expenses
+postCessationTradeRelief.summary.expenses.bullet4 = recovering debts that were taken into account in calculating your pre-cessation profits. This can include debts that have gone bad, or have been voluntarily released, within 7 years of cessation
+
+postCessationTradeRelief.summary.liabilities.heading = Relief for former employee’s liabilities and costs
+postCessationTradeRelief.summary.liabilities.p1.individual = If the amount of liabilities or costs to be entered relating to your actual or alleged wrongful acts in a former employment, exceed your total income in the year you may be able to claim the excess against capital gains. There are special rules limiting the relief if you did not pay for these costs, for example, yourself.
+postCessationTradeRelief.summary.liabilities.p1.agent = If the amount of liabilities or costs to be entered, relating to your client’s actual or alleged wrongful acts in a former employment, exceed their total income in the year, they may be able to claim the excess against capital gains. There are special rules limiting the relief if they did not pay for these costs, for example, themselves.
+
+postCessationTradeRelief.summary.loss.heading = Employment loss relief
+postCessationTradeRelief.summary.loss.p1 = Relief for losses arising from an employment or office is only available in exceptional circumstances. This is because, as a general rule, employment expenses cannot exceed the earnings from which they are deductible. A loss can sometimes arise where capital allowances due cannot be deducted from the earnings from the employment. Additionally, a loss may also come directly from the conditions of the employment. Otherwise, relief cannot usually be claimed for these losses.
+
+postCessationTradeRelief.label.individual = How much are you claiming for post-cessation trade relief and certain other losses?
+postCessationTradeRelief.label.agent = How much is your client claiming for post-cessation trade relief and certain other losses?
+
+postCessationTradeRelief.amount.error.required.individual = Enter how much relief you are claiming
+postCessationTradeRelief.amount.error.required.agent = Enter how much relief your client is claiming
+postCessationTradeRelief.amount.error.invalid = The amount of relief must only include the numbers 0-9 and a decimal point
+postCessationTradeRelief.amount.error.max.individual = The amount of your relief must be less than £100,000,000,000
+postCessationTradeRelief.amount.error.max.agent = The amount of your client’s relief must be less than £100,000,000,000
+postCessationTradeRelief.amount.error.min.individual = Enter a valid amount for how much relief you are claiming
+postCessationTradeRelief.amount.error.min.agent = Enter a valid amount for how much relief your client is claiming
+
+
 #################       Timeout messages        ########################################
 
 timeout.button = Sign in

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -308,6 +308,40 @@ taxYear-error-template.paragraph.1 = Dim ond gwybodaeth ar gyfer y blynyddoedd t
 taxYear-error-template.paragraph.1.single = Dim ond gwybodaeth ar gyfer blwyddyn dreth ddilys y gallwch ei nodi.
 taxYear-error-template.paragraph.2 = Gwiriwch eich bod wedi nodi’r cyfeiriad gwe cywir.
 
+#################       Business Tax Reliefs messages        ########################################
+
+### Post Cessation Trade Relief
+postCessationTradeRelief.title = Post-cessation trade relief and certain other losses (Welsh)
+
+postCessationTradeRelief.p1.individual = If you’ve paid expenses in connection with a business that has ceased, you may be able to get tax relief on those payments. This relief can only be claimed if you didn’t claim those expenses at the time the business ceased, or anywhere else in this or an earlier tax return. Post-cessation expenses are always set against post-cessation receipts first.  (Welsh)
+postCessationTradeRelief.p1.agent = If your client has paid expenses in connection with a business that has ceased, they may be able to get tax relief on those payments. This relief can only be claimed if they didn’t claim those expenses at the time the business ceased, or anywhere else in this or an earlier tax return. Post-cessation expenses are always set against post-cessation receipts first. (Welsh)
+postCessationTradeRelief.p2 = The expenses must be paid within 7 years of your cessation, and should be claimed against the tax return for the year the expense was paid. The claim must also be made by the anniversary of the filing deadline for the tax year in question. For example, a claim for an expense paid in the tax year 6 April 2026 to 5 April 2027 must be made by 31 January 2029. (Welsh)
+
+postCessationTradeRelief.summary.expenses.heading = Post-cessation expenses (Welsh)
+postCessationTradeRelief.summary.expenses.p1 = Post-cessation expenses are expenses that would have been taken from the business’s profits had it not ceased trading. These expenses are: (Welsh)
+postCessationTradeRelief.summary.expenses.bullet1 = fixing defective work done, or replacing defective services or goods supplied (Welsh)
+postCessationTradeRelief.summary.expenses.bullet2 = any legal or professional costs for any claim against you for defective work (Welsh)
+postCessationTradeRelief.summary.expenses.bullet3 = insurance against such expenses (Welsh)
+postCessationTradeRelief.summary.expenses.bullet4 = recovering debts that were taken into account in calculating your pre-cessation profits. This can include debts that have gone bad, or have been voluntarily released, within 7 years of cessation (Welsh)
+
+postCessationTradeRelief.summary.liabilities.heading = Relief for former employee’s liabilities and costs (Welsh)
+postCessationTradeRelief.summary.liabilities.p1.individual = If the amount of liabilities or costs to be entered relating to your actual or alleged wrongful acts in a former employment, exceed your total income in the year you may be able to claim the excess against capital gains. There are special rules limiting the relief if you did not pay for these costs, for example, yourself. (Welsh)
+postCessationTradeRelief.summary.liabilities.p1.agent = If the amount of liabilities or costs to be entered, relating to your client’s actual or alleged wrongful acts in a former employment, exceed their total income in the year, they may be able to claim the excess against capital gains. There are special rules limiting the relief if they did not pay for these costs, for example, themselves. (Welsh)
+
+postCessationTradeRelief.summary.loss.heading = Employment loss relief (Welsh)
+postCessationTradeRelief.summary.loss.p1 = Relief for losses arising from an employment or office is only available in exceptional circumstances. This is because, as a general rule, employment expenses cannot exceed the earnings from which they are deductible. A loss can sometimes arise where capital allowances due cannot be deducted from the earnings from the employment. Additionally, a loss may also come directly from the conditions of the employment. Otherwise, relief cannot usually be claimed for these losses. (Welsh)
+
+postCessationTradeRelief.label.individual = How much are you claiming for post-cessation trade relief and certain other losses? (Welsh)
+postCessationTradeRelief.label.agent = How much is your client claiming for post-cessation trade relief and certain other losses? (Welsh)
+
+postCessationTradeRelief.amount.error.required.individual = Enter how much relief you are claiming (Welsh)
+postCessationTradeRelief.amount.error.required.agent = Enter how much relief your client is claiming (Welsh)
+postCessationTradeRelief.amount.error.invalid = The amount of relief must only include the numbers 0-9 and a decimal point (Welsh)
+postCessationTradeRelief.amount.error.max.individual = The amount of your relief must be less than £100,000,000,000 (Welsh)
+postCessationTradeRelief.amount.error.max.agent = The amount of your client’s relief must be less than £100,000,000,000 (Welsh)
+postCessationTradeRelief.amount.error.min.individual = Enter a valid amount for how much relief you are claiming (Welsh)
+postCessationTradeRelief.amount.error.min.agent = Enter a valid amount for how much relief your client is claiming (Welsh)
+
 #################       Timeout messages        ########################################
 
 timeout.button = Mewngofnodi

--- a/it/test/controllers/businessTaxReliefs/PostCessationTradeReliefControllerISpec.scala
+++ b/it/test/controllers/businessTaxReliefs/PostCessationTradeReliefControllerISpec.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.businessTaxReliefs
+
+import fixtures.messages.businessTaxReliefs.PostCessationTradeReliefMessages
+import forms.businessTaxReliefs.PostCessationTradeReliefForm
+import org.scalatest.OptionValues.convertOptionToValuable
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.http.HeaderNames
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.api.{Application, Environment, Mode}
+import test.support.IntegrationTest
+
+class PostCessationTradeReliefControllerISpec extends IntegrationTest {
+
+  lazy val application: Application = GuiceApplicationBuilder()
+    .in(Environment.simple(mode = Mode.Dev))
+    .configure(config)
+    .build()
+
+  private def url(taxYear: Int): String =
+    s"/update-and-submit-income-tax-return/additional-information/$taxYear/business-reliefs/post-cessation-trade-relief/relief-claimed"
+
+  ".show" when {
+
+    "user is an Agent" should {
+
+      "render the Post-Cessation Trade Relief amount page" in {
+
+        authoriseAgentOrIndividual(isAgent = true)
+
+        val request = FakeRequest(GET, url(taxYear)).withHeaders(HeaderNames.COOKIE -> playSessionCookies(taxYear))
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) must include(PostCessationTradeReliefMessages.EnglishAgent.headingAndTitle)
+      }
+    }
+
+    "user is an Individual" should {
+
+      "render the Post-Cessation Trade Relief amount page" in {
+
+        authoriseAgentOrIndividual(isAgent = false)
+
+        val request = FakeRequest(GET, url(taxYear)).withHeaders(HeaderNames.COOKIE -> playSessionCookies(taxYear))
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) must include(PostCessationTradeReliefMessages.English.headingAndTitle)
+      }
+    }
+  }
+
+  ".submit" should {
+
+    "user is an Agent" should {
+
+      "valid data is submitted" should {
+
+        "redirect to the Check Your Answers page" in {
+
+          authoriseAgentOrIndividual(isAgent = true)
+
+          val request = FakeRequest(POST, url(taxYear))
+            .withHeaders(HeaderNames.COOKIE -> playSessionCookies(taxYear), "Csrf-Token" -> "nocheck")
+            .withFormUrlEncodedBody(PostCessationTradeReliefForm.key -> "1000.00")
+
+          val result = route(application, request).value
+
+          //TODO: In future story, this will be updated to redirect to the CYA page
+          status(result) mustEqual NOT_IMPLEMENTED
+        }
+      }
+
+      "invalid data is submitted" should {
+
+        "render the page as a bad request" in {
+
+          authoriseAgentOrIndividual(isAgent = true)
+
+          val request = FakeRequest(POST, url(taxYear))
+            .withHeaders(HeaderNames.COOKIE -> playSessionCookies(taxYear), "Csrf-Token" -> "nocheck")
+            .withFormUrlEncodedBody(PostCessationTradeReliefForm.key -> "")
+
+          val result = route(application, request).value
+
+          status(result) mustEqual BAD_REQUEST
+          contentAsString(result) must include(PostCessationTradeReliefMessages.EnglishAgent.amountEmpty)
+        }
+      }
+    }
+
+    "user is an Individual" should {
+
+      "valid data is submitted" should {
+
+        "redirect to the Check Your Answers page" in {
+
+          authoriseAgentOrIndividual(isAgent = false)
+
+          val request = FakeRequest(POST, url(taxYear))
+            .withHeaders(HeaderNames.COOKIE -> playSessionCookies(taxYear), "Csrf-Token" -> "nocheck")
+            .withFormUrlEncodedBody(PostCessationTradeReliefForm.key -> "1000.00")
+
+          val result = route(application, request).value
+
+          //TODO: In future story, this will be updated to redirect to the CYA page
+          status(result) mustEqual NOT_IMPLEMENTED
+        }
+      }
+
+      "invalid data is submitted" should {
+
+        "render the page as a bad request" in {
+
+          authoriseAgentOrIndividual(isAgent = true)
+
+          val request = FakeRequest(POST, url(taxYear))
+            .withHeaders(HeaderNames.COOKIE -> playSessionCookies(taxYear), "Csrf-Token" -> "nocheck")
+            .withFormUrlEncodedBody(PostCessationTradeReliefForm.key -> "")
+
+          val result = route(application, request).value
+
+          status(result) mustEqual BAD_REQUEST
+          contentAsString(result) must include(PostCessationTradeReliefMessages.EnglishAgent.amountEmpty)
+        }
+      }
+    }
+  }
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -18,9 +18,9 @@ import sbt.*
 
 object AppDependencies {
 
-  private val hmrcMongoPlayVersion = "2.5.0"
+  private val hmrcMongoPlayVersion = "2.6.0"
   private val bootstrapPlay30Version = "9.11.0"
-  private val hmrcPlayFrontend = "11.12.0"
+  private val hmrcPlayFrontend = "11.13.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"                   %% "bootstrap-frontend-play-30" % bootstrapPlay30Version,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.10

--- a/test/fixtures/messages/businessTaxReliefs/PostCessationTradeReliefMessages.scala
+++ b/test/fixtures/messages/businessTaxReliefs/PostCessationTradeReliefMessages.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixtures.messages.businessTaxReliefs
+
+import fixtures.messages.{Cy, En, i18n}
+
+object PostCessationTradeReliefMessages {
+
+  sealed trait Messages { _: i18n =>
+    val headingAndTitle = "Post-cessation trade relief and certain other losses"
+    val p1 = "If you’ve paid expenses in connection with a business that has ceased, you may be able to get tax relief on those payments. This relief can only be claimed if you didn’t claim those expenses at the time the business ceased, or anywhere else in this or an earlier tax return. Post-cessation expenses are always set against post-cessation receipts first."
+    val p2 = "The expenses must be paid within 7 years of your cessation, and should be claimed against the tax return for the year the expense was paid. The claim must also be made by the anniversary of the filing deadline for the tax year in question. For example, a claim for an expense paid in the tax year 6 April 2026 to 5 April 2027 must be made by 31 January 2029."
+    val expensesSummaryHeading = "Post-cessation expenses"
+    val expensesSummaryP1 = "Post-cessation expenses are expenses that would have been taken from the business’s profits had it not ceased trading. These expenses are:"
+    val expensesSummaryBullet1 = "fixing defective work done, or replacing defective services or goods supplied"
+    val expensesSummaryBullet2 = "any legal or professional costs for any claim against you for defective work"
+    val expensesSummaryBullet3 = "insurance against such expenses"
+    val expensesSummaryBullet4 = "recovering debts that were taken into account in calculating your pre-cessation profits. This can include debts that have gone bad, or have been voluntarily released, within 7 years of cessation"
+    val liabilitiesSummaryHeading = "Relief for former employee’s liabilities and costs"
+    val liabilitiesSummaryP1 = "If the amount of liabilities or costs to be entered relating to your actual or alleged wrongful acts in a former employment, exceed your total income in the year you may be able to claim the excess against capital gains. There are special rules limiting the relief if you did not pay for these costs, for example, yourself."
+    val lossSummaryHeading = "Employment loss relief"
+    val lossSummaryP1 = "Relief for losses arising from an employment or office is only available in exceptional circumstances. This is because, as a general rule, employment expenses cannot exceed the earnings from which they are deductible. A loss can sometimes arise where capital allowances due cannot be deducted from the earnings from the employment. Additionally, a loss may also come directly from the conditions of the employment. Otherwise, relief cannot usually be claimed for these losses."
+    val label = "How much are you claiming for post-cessation trade relief and certain other losses?"
+
+    val amountEmpty = "Enter how much relief you are claiming"
+    val amountInvalid = "The amount of relief must only include the numbers 0-9 and a decimal point"
+    val amountTooLarge = "The amount of your relief must be less than £100,000,000,000"
+    val amountTooSmall = "Enter a valid amount for how much relief you are claiming"
+  }
+
+  object English extends Messages with En
+
+  object EnglishAgent extends Messages with En {
+    override val p1 = "If your client has paid expenses in connection with a business that has ceased, they may be able to get tax relief on those payments. This relief can only be claimed if they didn’t claim those expenses at the time the business ceased, or anywhere else in this or an earlier tax return. Post-cessation expenses are always set against post-cessation receipts first."
+    override val liabilitiesSummaryP1 = "If the amount of liabilities or costs to be entered, relating to your client’s actual or alleged wrongful acts in a former employment, exceed their total income in the year, they may be able to claim the excess against capital gains. There are special rules limiting the relief if they did not pay for these costs, for example, themselves."
+    override val label = "How much is your client claiming for post-cessation trade relief and certain other losses?"
+
+    override val amountEmpty = "Enter how much relief your client is claiming"
+    override val amountTooLarge = "The amount of your client’s relief must be less than £100,000,000,000"
+    override val amountTooSmall = "Enter a valid amount for how much relief your client is claiming"
+  }
+
+  object Welsh extends Messages with Cy {
+    override val headingAndTitle = "Post-cessation trade relief and certain other losses (Welsh)"
+    override val p1 = "If you’ve paid expenses in connection with a business that has ceased, you may be able to get tax relief on those payments. This relief can only be claimed if you didn’t claim those expenses at the time the business ceased, or anywhere else in this or an earlier tax return. Post-cessation expenses are always set against post-cessation receipts first. (Welsh)"
+    override val p2 = "The expenses must be paid within 7 years of your cessation, and should be claimed against the tax return for the year the expense was paid. The claim must also be made by the anniversary of the filing deadline for the tax year in question. For example, a claim for an expense paid in the tax year 6 April 2026 to 5 April 2027 must be made by 31 January 2029. (Welsh)"
+    override val expensesSummaryHeading = "Post-cessation expenses (Welsh)"
+    override val expensesSummaryP1 = "Post-cessation expenses are expenses that would have been taken from the business’s profits had it not ceased trading. These expenses are: (Welsh)"
+    override val expensesSummaryBullet1 = "fixing defective work done, or replacing defective services or goods supplied (Welsh)"
+    override val expensesSummaryBullet2 = "any legal or professional costs for any claim against you for defective work (Welsh)"
+    override val expensesSummaryBullet3 = "insurance against such expenses (Welsh)"
+    override val expensesSummaryBullet4 = "recovering debts that were taken into account in calculating your pre-cessation profits. This can include debts that have gone bad, or have been voluntarily released, within 7 years of cessation (Welsh)"
+    override val liabilitiesSummaryHeading = "Relief for former employee’s liabilities and costs (Welsh)"
+    override val liabilitiesSummaryP1 = "If the amount of liabilities or costs to be entered relating to your actual or alleged wrongful acts in a former employment, exceed your total income in the year you may be able to claim the excess against capital gains. There are special rules limiting the relief if you did not pay for these costs, for example, yourself. (Welsh)"
+    override val lossSummaryHeading = "Employment loss relief (Welsh)"
+    override val lossSummaryP1 = "Relief for losses arising from an employment or office is only available in exceptional circumstances. This is because, as a general rule, employment expenses cannot exceed the earnings from which they are deductible. A loss can sometimes arise where capital allowances due cannot be deducted from the earnings from the employment. Additionally, a loss may also come directly from the conditions of the employment. Otherwise, relief cannot usually be claimed for these losses. (Welsh)"
+    override val label = "How much are you claiming for post-cessation trade relief and certain other losses? (Welsh)"
+
+    override val amountEmpty = "Enter how much relief you are claiming (Welsh)"
+    override val amountInvalid = "The amount of relief must only include the numbers 0-9 and a decimal point (Welsh)"
+    override val amountTooLarge = "The amount of your relief must be less than £100,000,000,000 (Welsh)"
+    override val amountTooSmall = "Enter a valid amount for how much relief you are claiming (Welsh)"
+  }
+
+  object WelshAgent extends Messages with Cy {
+    override val headingAndTitle = Welsh.headingAndTitle
+    override val p1 = "If your client has paid expenses in connection with a business that has ceased, they may be able to get tax relief on those payments. This relief can only be claimed if they didn’t claim those expenses at the time the business ceased, or anywhere else in this or an earlier tax return. Post-cessation expenses are always set against post-cessation receipts first. (Welsh)"
+    override val p2 = Welsh.p2
+    override val expensesSummaryHeading = Welsh.expensesSummaryHeading
+    override val expensesSummaryP1 = Welsh.expensesSummaryP1
+    override val expensesSummaryBullet1 = Welsh.expensesSummaryBullet1
+    override val expensesSummaryBullet2 = Welsh.expensesSummaryBullet2
+    override val expensesSummaryBullet3 = Welsh.expensesSummaryBullet3
+    override val expensesSummaryBullet4 = Welsh.expensesSummaryBullet4
+    override val liabilitiesSummaryHeading = Welsh.liabilitiesSummaryHeading
+    override val liabilitiesSummaryP1 = "If the amount of liabilities or costs to be entered, relating to your client’s actual or alleged wrongful acts in a former employment, exceed their total income in the year, they may be able to claim the excess against capital gains. There are special rules limiting the relief if they did not pay for these costs, for example, themselves. (Welsh)"
+    override val lossSummaryHeading = Welsh.lossSummaryHeading
+    override val lossSummaryP1 = Welsh.lossSummaryP1
+    override val label = "How much is your client claiming for post-cessation trade relief and certain other losses? (Welsh)"
+
+    override val amountEmpty = "Enter how much relief your client is claiming (Welsh)"
+    override val amountInvalid = Welsh.amountInvalid
+    override val amountTooLarge = "The amount of your client’s relief must be less than £100,000,000,000 (Welsh)"
+    override val amountTooSmall = "Enter a valid amount for how much relief your client is claiming (Welsh)"
+  }
+}

--- a/test/fixtures/messages/i18n.scala
+++ b/test/fixtures/messages/i18n.scala
@@ -1,5 +1,5 @@
-@*
- * Copyright 2023 HM Revenue & Customs
+/*
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,18 +12,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@this()
+package fixtures.messages
 
-@(content: Html, classes: String = "govuk-body", id: Option[String] = None)
+import play.api.i18n.Lang
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{Cy, En, Language}
 
-@if(id.isDefined){
-    <p class="@classes" id ="@id">@content</p>
-} else {
-    <p class="@classes">@content</p>
+sealed trait i18n {
+  val language: Language
+  lazy val lang: Lang = Lang(language.code)
+  val continue = "Continue"
 }
 
-@{
-//$COVERAGE-OFF$
+trait En extends i18n {
+  override val language: Language = En
+}
+
+trait Cy extends i18n {
+  override val language: Language = Cy
+  override val continue = "Yn eich blaen"
 }

--- a/test/forms/businessTaxReliefs/PostCessationTradeReliefFormSpec.scala
+++ b/test/forms/businessTaxReliefs/PostCessationTradeReliefFormSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.businessTaxReliefs
+
+import fixtures.messages.businessTaxReliefs.PostCessationTradeReliefMessages
+import forms.businessTaxReliefs.PostCessationTradeReliefForm.{key => formKey}
+import models.requests.AuthorisationRequest
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.data.FormError
+import play.api.i18n.{Messages, MessagesApi}
+import support.UnitTest
+
+class PostCessationTradeReliefFormSpec extends UnitTest with GuiceOneAppPerSuite {
+
+  lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+
+  Seq(
+    false -> PostCessationTradeReliefMessages.English,
+    true -> PostCessationTradeReliefMessages.EnglishAgent,
+    false -> PostCessationTradeReliefMessages.Welsh,
+    true -> PostCessationTradeReliefMessages.WelshAgent
+  ).foreach { case (isAgent, messagesForLanguage) =>
+
+    s"when the form is rendered with language of '${messagesForLanguage.language.name}'" when {
+
+      implicit val msgs: Messages = messagesApi.preferred(Seq(messagesForLanguage.lang))
+
+      s"the user is an ${if(isAgent) "Agent" else "Individual"}" when {
+
+        implicit val request: AuthorisationRequest[_] = if (isAgent) agentRequest else individualRequest
+
+        "bind valid values" when {
+
+          "amount is greater than 0 (0dp)" in {
+            PostCessationTradeReliefForm().bind(Map(formKey -> "1")).value shouldBe Some(1)
+          }
+
+          "amount is greater than 0 (1dp)" in {
+            PostCessationTradeReliefForm().bind(Map(formKey -> "1.1")).value shouldBe Some(1.1)
+          }
+
+          "amount is greater than 0 (2dp)" in {
+            PostCessationTradeReliefForm().bind(Map(formKey -> "1.12")).value shouldBe Some(1.12)
+          }
+
+          "amount contains commas (2dp)" in {
+            PostCessationTradeReliefForm().bind(Map(formKey -> "1,000,569.12")).value shouldBe Some(1000569.12)
+          }
+        }
+
+        "return correct error message for invalid values" when {
+
+          "amount is empty" in {
+            val boundForm = PostCessationTradeReliefForm().bind(Map(formKey -> ""))
+            boundForm.errors should contain(FormError(formKey, messagesForLanguage.amountEmpty))
+          }
+
+          "amount contains a non numeric values" in {
+            val boundForm = PostCessationTradeReliefForm().bind(Map(formKey -> "number"))
+            boundForm.errors should contain(FormError(formKey, messagesForLanguage.amountInvalid))
+          }
+
+          "amount is zero" in {
+            val boundForm = PostCessationTradeReliefForm().bind(Map(formKey -> "0"))
+            boundForm.errors should contain(FormError(formKey, messagesForLanguage.amountTooSmall))
+          }
+
+          "amount too big" in {
+            val boundForm = PostCessationTradeReliefForm().bind(Map(formKey -> "10000000000000000"))
+            boundForm.errors should contain(FormError(formKey, messagesForLanguage.amountTooLarge))
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/support/UnitTest.scala
+++ b/test/support/UnitTest.scala
@@ -16,15 +16,20 @@
 
 package support
 
+import models.User
+import models.requests.AuthorisationRequest
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
+import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 import uk.gov.hmrc.http.HeaderCarrier
 
 trait UnitTest extends AnyWordSpec with Matchers with MockFactory with BeforeAndAfterEach
   with FutureAwaits with DefaultAwaitTimeout {
 
   implicit val emptyHeaderCarrier: HeaderCarrier = HeaderCarrier()
+
+  val agentRequest: AuthorisationRequest[_] = AuthorisationRequest(User("123", Some("arn"), "AA12346B", "Agent", "sessionId"), FakeRequest())
+  val individualRequest: AuthorisationRequest[_] = AuthorisationRequest(User("123", None, "AA12346B", "Individual", "sessionId"), FakeRequest())
 }

--- a/test/support/helpers/ViewHelper.scala
+++ b/test/support/helpers/ViewHelper.scala
@@ -69,7 +69,7 @@ trait ViewHelper {
 
   def textOnPageCheck(text: String, selector: String, additionalTestText: String = "")(implicit document: Document): Unit = {
     s"have text on the screen of '$text' $additionalTestText" in {
-      document.select(selector).text() shouldBe text
+      document.select(selector).text() should include(text)
     }
   }
 

--- a/test/utils/ViewUtilsSpec.scala
+++ b/test/utils/ViewUtilsSpec.scala
@@ -16,8 +16,11 @@
 
 package utils
 
+import models.User
+import models.requests.AuthorisationRequest
 import org.scalamock.scalatest.MockFactory
 import play.api.i18n.{Lang, Messages}
+import play.api.test.FakeRequest
 import play.i18n
 import support.UnitTest
 
@@ -49,6 +52,28 @@ class ViewUtilsSpec extends UnitTest
   ".translatedDateFormatter" should {
     "translate date" in {
       ViewUtils.translatedDateFormatter(LocalDate.parse("2002-01-01"))(messages = messages) shouldBe "1 January 2002"
+    }
+  }
+
+  ".dynamicMessage" when {
+    "request is from an Agent" should {
+      "output the Agent message" in {
+
+        implicit val request: AuthorisationRequest[_] = agentRequest
+        implicit val msgs: Messages = messages
+
+        ViewUtils.dynamicMessage("common.test") shouldBe "Test.agent"
+      }
+    }
+
+    "request is from an Individual" should {
+      "output the Individual message" in {
+
+        implicit val request: AuthorisationRequest[_] = individualRequest
+        implicit val msgs: Messages = messages
+
+        ViewUtils.dynamicMessage("common.test") shouldBe "Test.individual"
+      }
     }
   }
 }

--- a/test/views/pages/businessTaxReliefs/PostCessationTradeReliefViewSpec.scala
+++ b/test/views/pages/businessTaxReliefs/PostCessationTradeReliefViewSpec.scala
@@ -34,12 +34,12 @@ class PostCessationTradeReliefViewSpec extends ViewUnitTest {
 
   object Selectors extends BaseSelectors {
     val expensesSummary = "#detailExpenses summary"
-    val expensesP: Int => String = i => s"#detailExpenses div ${Selectors.p(i)}"
-    val expensesBullet: Int => String = i => s"#detailExpenses div ${Selectors.bullet(i)}"
+    def expensesP(nth: Int): String = s"#detailExpenses div ${Selectors.p(nth)}"
+    def expensesBullet(nth: Int): String = s"#detailExpenses div ${Selectors.bullet(nth)}"
     val liabilitiesSummary = "#detailLiabilities summary"
-    val liabilitiesP: Int => String = i => s"#detailLiabilities div ${Selectors.p(i)}"
+    def liabilitiesP(nth: Int): String = s"#detailLiabilities div ${Selectors.p(nth)}"
     val lossSummary = "#detailLoss summary"
-    val lossP: Int => String = i => s"#detailLoss div ${Selectors.p(i)}"
+    def lossP(nth: Int): String = s"#detailLoss div ${Selectors.p(nth)}"
   }
 
   override protected val userScenarios: Seq[UserScenario[PostCessationTradeReliefMessages.Messages with i18n, _]] = Seq(

--- a/test/views/pages/businessTaxReliefs/PostCessationTradeReliefViewSpec.scala
+++ b/test/views/pages/businessTaxReliefs/PostCessationTradeReliefViewSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.pages.businessTaxReliefs
+
+import fixtures.messages.businessTaxReliefs.PostCessationTradeReliefMessages
+import fixtures.messages.i18n
+import forms.businessTaxReliefs.PostCessationTradeReliefForm
+import models.requests.AuthorisationRequest
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.i18n.Messages
+import play.api.mvc.AnyContent
+import support.ViewUnitTest
+import views.html.pages.businessTaxReliefs.PostCessationTradeReliefView
+import views.utils.BaseSelectors
+
+class PostCessationTradeReliefViewSpec extends ViewUnitTest {
+
+  private val page: PostCessationTradeReliefView = inject[PostCessationTradeReliefView]
+
+  object Selectors extends BaseSelectors {
+    val expensesSummary = "#detailExpenses summary"
+    val expensesP: Int => String = i => s"#detailExpenses div ${Selectors.p(i)}"
+    val expensesBullet: Int => String = i => s"#detailExpenses div ${Selectors.bullet(i)}"
+    val liabilitiesSummary = "#detailLiabilities summary"
+    val liabilitiesP: Int => String = i => s"#detailLiabilities div ${Selectors.p(i)}"
+    val lossSummary = "#detailLoss summary"
+    val lossP: Int => String = i => s"#detailLoss div ${Selectors.p(i)}"
+  }
+
+  override protected val userScenarios: Seq[UserScenario[PostCessationTradeReliefMessages.Messages with i18n, _]] = Seq(
+    UserScenario(isWelsh = false, isAgent = false, PostCessationTradeReliefMessages.English),
+    UserScenario(isWelsh = false, isAgent = true, PostCessationTradeReliefMessages.EnglishAgent),
+    UserScenario(isWelsh = true, isAgent = false, PostCessationTradeReliefMessages.Welsh),
+    UserScenario(isWelsh = true, isAgent = true, PostCessationTradeReliefMessages.WelshAgent)
+  )
+
+  userScenarios.foreach { userScenario =>
+
+    s"language is ${welshTest(userScenario.isWelsh)} and request is from an ${agentTest(userScenario.isAgent)}" should {
+
+      "render post-cessation trade relief amount page" which {
+
+        implicit val request: AuthorisationRequest[AnyContent] = getAuthRequest(userScenario.isAgent)
+        implicit val messages: Messages = getMessages(userScenario.isWelsh)
+
+        implicit val document: Document = Jsoup.parse(page(
+          taxYear = taxYear,
+          form = PostCessationTradeReliefForm(),
+          action = controllers.businessTaxReliefs.routes.PostCessationTradeReliefController.submit(taxYear)
+        ).body)
+
+        val expectedMessages = userScenario.commonExpectedResults
+
+        welshToggleCheck(userScenario.isWelsh)
+        titleCheck(expectedMessages.headingAndTitle, userScenario.isWelsh)
+        h1Check(expectedMessages.headingAndTitle)
+        textOnPageCheck(expectedMessages.p1, "main " + Selectors.p(1))
+        textOnPageCheck(expectedMessages.p2, "main " + Selectors.p(2))
+        textOnPageCheck(expectedMessages.expensesSummaryHeading, Selectors.expensesSummary)
+        textOnPageCheck(expectedMessages.expensesSummaryP1, Selectors.expensesP(1))
+        textOnPageCheck(expectedMessages.expensesSummaryBullet1, Selectors.expensesBullet(1))
+        textOnPageCheck(expectedMessages.expensesSummaryBullet2, Selectors.expensesBullet(2))
+        textOnPageCheck(expectedMessages.expensesSummaryBullet3, Selectors.expensesBullet(3))
+        textOnPageCheck(expectedMessages.expensesSummaryBullet4, Selectors.expensesBullet(4))
+        textOnPageCheck(expectedMessages.liabilitiesSummaryHeading, Selectors.liabilitiesSummary)
+        textOnPageCheck(expectedMessages.liabilitiesSummaryP1, Selectors.liabilitiesP(1))
+        textOnPageCheck(expectedMessages.lossSummaryHeading, Selectors.lossSummary)
+        textOnPageCheck(expectedMessages.lossSummaryP1, Selectors.lossP(1))
+        buttonCheck(expectedMessages.continue)
+      }
+    }
+  }
+}

--- a/test/views/utils/BaseSelectors.scala
+++ b/test/views/utils/BaseSelectors.scala
@@ -18,8 +18,6 @@ package views.utils
 
 trait BaseSelectors {
 
-  def concat(selectors: String*): String = selectors.mkString(" ")
-
   val h1 = "h1"
   val h2: Int => String = i => s"h2:nth-of-type($i)"
   val p: Int => String = i => s"p:nth-of-type($i)"

--- a/test/views/utils/BaseSelectors.scala
+++ b/test/views/utils/BaseSelectors.scala
@@ -1,5 +1,5 @@
-@*
- * Copyright 2023 HM Revenue & Customs
+/*
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,18 +12,18 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@this()
+package views.utils
 
-@(content: Html, classes: String = "govuk-body", id: Option[String] = None)
+trait BaseSelectors {
 
-@if(id.isDefined){
-    <p class="@classes" id ="@id">@content</p>
-} else {
-    <p class="@classes">@content</p>
-}
+  def concat(selectors: String*): String = selectors.mkString(" ")
 
-@{
-//$COVERAGE-OFF$
+  val h1 = "h1"
+  val h2: Int => String = i => s"h2:nth-of-type($i)"
+  val p: Int => String = i => s"p:nth-of-type($i)"
+  val bullet: Int => String = i => s"ul li:nth-of-type($i)"
+  val summary = "summary"
+
 }

--- a/test/views/utils/BaseSelectors.scala
+++ b/test/views/utils/BaseSelectors.scala
@@ -19,9 +19,9 @@ package views.utils
 trait BaseSelectors {
 
   val h1 = "h1"
-  val h2: Int => String = i => s"h2:nth-of-type($i)"
-  val p: Int => String = i => s"p:nth-of-type($i)"
-  val bullet: Int => String = i => s"ul li:nth-of-type($i)"
+  def h2(nth: Int): String = s"h2:nth-of-type($nth)"
+  def p(nth: Int): String = s"p:nth-of-type($nth)"
+  def bullet(nth: Int): String = s"ul li:nth-of-type($nth)"
   val summary = "summary"
 
 }


### PR DESCRIPTION
### Description
New page build for Business Tax Reliefs. Added the `Post-Cessation Trade Relief` page. Includes content for English, Welsh and Invdividual and Agent variants. (Welsh content is suffixed `(Welsh)` so we know this still needs translating). 

Saving/Retrieving of the answer will need to be completed as part of a future Tech story to provide the wiring and implementation for this.